### PR TITLE
[Nit][EZ] Fix VSCode Pylint settings to resolve compatibility issue

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   "javascript.validate.enable": false,
   "python.formatting.provider": "yapf",
   "python.analysis.typeCheckingMode": "basic",
+  "pylint.args": ["--disable=E0015"],
   "[python]": {
     "editor.codeActionsOnSave": {
       "source.organizeImports": true


### PR DESCRIPTION
Disable the E0015: unrecognized-option error in the VSCode Pylint plugin. This is caused by compability issue, since our .pylintrc works with Pylint (2.15.4) but VSCode Pylint plugin still uses Pylint (2.12.2).

## Screenshot
- **Before**
![Before](https://www.dropbox.com/s/bkcwau980cw08xr/Screen%20Shot%202022-10-28%20at%2022.24.36.png?raw=1)

- **After**
![After](https://www.dropbox.com/s/ga1dqjm5hpojz8d/Screen%20Shot%202022-10-28%20at%2022.24.55.png?raw=1)