### PR TITLE
[Infra] Remove linting and type check from git pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,15 +73,10 @@
   },
   "lint-staged": {
     "*.{js,md,json}": "prettier --write",
-    "*.js": [
-      "eslint --fix",
-      "flow"
-    ],
+    "*.js": "eslint --fix",
     "*.py": [
       "yapf -i",
-      "isort",
-      "pylint",
-      "pyright"
+      "isort"
     ]
   }
 }


### PR DESCRIPTION
## Summary

It's better to remove linting and type check from git pre-commit hook (lint-staged). They are now performed as GitHub actions (in [this PR](https://github.com/SPiCaRiA/Class-Route-Tester/pull/7)).

## Test Plan

N/A
