### PR TITLE
[Infra][Fix] Solve WSL Ubuntu compatibility issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "eject": "react-scripts eject",
     "flow-src": "flow src",
     "prepare": "husky install",
-    "pre-commit": "source .venv/bin/activate && lint-staged",
-    "api": "source .venv/bin/activate && python -m class_route_api"
+    "pre-commit": ". .venv/bin/activate && lint-staged",
+    "api": ". .venv/bin/activate && python -m class_route_api"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
## Summary

We've discovered that the `source` command is missing in WSL Ubuntu environment, so we will use `.` instead to activate the Python virtual environment.

## Test Plan

Works as usual on MacOS, expect to work on WSL Ubuntu.

Run `yarn api start`:

![Run API start](https://www.dropbox.com/s/cbmxxukd8ehxu7q/Screen%20Shot%202022-11-04%20at%2014.33.53.png?raw=1)
