### PR TITLE
Add error popup

### DIFF
--- a/src/analytics/AnalyticsPage.react.js
+++ b/src/analytics/AnalyticsPage.react.js
@@ -10,11 +10,14 @@ import Container from '@mui/material/Container';
 import ScopedCssBaseline from '@mui/material/ScopedCssBaseline';
 import * as React from 'react';
 
+import AnalyticsErrorAlert from './components/AnalyticsErrorAlert.react';
+
 type Props = $ReadOnly<{}>;
 
 export default function AnalyticsPage(_props: Props): React.MixedElement {
   return (
     <ScopedCssBaseline>
+      <AnalyticsErrorAlert />
       <Container>
         <AnalyticsHeader />
         <MainCard />

--- a/src/analytics/AnalyticsPage.react.js
+++ b/src/analytics/AnalyticsPage.react.js
@@ -3,24 +3,37 @@
  * @author Daniel Tat
  */
 
+import AnalyticsErrorAlert from 'AnalyticsErrorAlert.react';
 import AnalyticsHeader from 'AnalyticsHeader.react';
-import MainCard from 'AnalyticsMainCard.react';
+import AnalyticsMainCard from 'AnalyticsMainCard.react';
 
+import {Collapse} from '@mui/material';
 import Container from '@mui/material/Container';
 import ScopedCssBaseline from '@mui/material/ScopedCssBaseline';
+import {useCallback, useState} from 'react';
 import * as React from 'react';
-
-import AnalyticsErrorAlert from './components/AnalyticsErrorAlert.react';
 
 type Props = $ReadOnly<{}>;
 
 export default function AnalyticsPage(_props: Props): React.MixedElement {
+  const [open, setOpen] = useState(false);
+
   return (
     <ScopedCssBaseline>
-      <AnalyticsErrorAlert />
+      <Collapse in={open}>
+        <AnalyticsErrorAlert
+          closeButtonOnClick={useCallback(() => {
+            setOpen(false);
+          })}
+        />
+      </Collapse>
       <Container>
         <AnalyticsHeader />
-        <MainCard />
+        <AnalyticsMainCard
+          searchButtonOnClick={useCallback(() => {
+            setOpen(true);
+          })}
+        />
       </Container>
     </ScopedCssBaseline>
   );

--- a/src/analytics/components/AnalyticsErrorAlert.react.js
+++ b/src/analytics/components/AnalyticsErrorAlert.react.js
@@ -1,40 +1,34 @@
-import {Button, Collapse, IconButton} from '@mui/material';
+import {IconButton} from '@mui/material';
 import Alert from '@mui/material/Alert';
 import AlertTitle from '@mui/material/AlertTitle';
+import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
-import {Box} from '@mui/system';
+import PropTypes from 'prop-types';
 import * as React from 'react';
 
-export default function AnalyticsErrorAlert() {
-  const [open, setOpen] = React.useState(false);
+AnalyticsErrorAlert.propTypes = {
+  closeButtonOnClick: PropTypes.func,
+};
 
-  function openError() {
-    setOpen(true);
-  }
-
+export default function AnalyticsErrorAlert({closeButtonOnClick}) {
   return (
     <Box>
-      <Collapse in={open}>
-        <Stack sx={{width: '50%'}} spacing={2}>
-          <Alert
-            severity="error"
-            action={
-              <IconButton
-                aria-label="close"
-                color="inherit"
-                size="small"
-                onClick={() => {
-                  setOpen(false);
-                }}>
-                X
-              </IconButton>
-            }>
-            <AlertTitle>Error</AlertTitle>
-            Failed to fetch results.
-          </Alert>
-        </Stack>
-      </Collapse>
-      <Button onClick={openError}>Trigger Error Alert</Button>
+      <Stack sx={{width: '50%'}} spacing={2}>
+        <Alert
+          severity="error"
+          action={
+            <IconButton
+              aria-label="close"
+              color="inherit"
+              size="small"
+              onClick={closeButtonOnClick}>
+              X
+            </IconButton>
+          }>
+          <AlertTitle>Error</AlertTitle>
+          Failed to fetch results.
+        </Alert>
+      </Stack>
     </Box>
   );
 }

--- a/src/analytics/components/AnalyticsErrorAlert.react.js
+++ b/src/analytics/components/AnalyticsErrorAlert.react.js
@@ -1,0 +1,40 @@
+import {Button, Collapse, IconButton} from '@mui/material';
+import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
+import Stack from '@mui/material/Stack';
+import {Box} from '@mui/system';
+import * as React from 'react';
+
+export default function AnalyticsErrorAlert() {
+  const [open, setOpen] = React.useState(false);
+
+  function openError() {
+    setOpen(true);
+  }
+
+  return (
+    <Box>
+      <Collapse in={open}>
+        <Stack sx={{width: '50%'}} spacing={2}>
+          <Alert
+            severity="error"
+            action={
+              <IconButton
+                aria-label="close"
+                color="inherit"
+                size="small"
+                onClick={() => {
+                  setOpen(false);
+                }}>
+                X
+              </IconButton>
+            }>
+            <AlertTitle>Error</AlertTitle>
+            Failed to fetch results.
+          </Alert>
+        </Stack>
+      </Collapse>
+      <Button onClick={openError}>Trigger Error Alert</Button>
+    </Box>
+  );
+}

--- a/src/analytics/components/AnalyticsErrorAlert.react.js
+++ b/src/analytics/components/AnalyticsErrorAlert.react.js
@@ -13,8 +13,9 @@ AnalyticsErrorAlert.propTypes = {
 export default function AnalyticsErrorAlert({closeButtonOnClick}) {
   return (
     <Box>
-      <Stack sx={{width: '50%'}} spacing={2}>
+      <Stack sx={{pt: '8px'}} alignItems="center" spacing={2}>
         <Alert
+          sx={{py: '20px', px: '32px'}}
           severity="error"
           action={
             <IconButton

--- a/src/analytics/components/AnalyticsFilter.react.js
+++ b/src/analytics/components/AnalyticsFilter.react.js
@@ -4,9 +4,14 @@ import Button from '@mui/material/Button';
 import FormControl from '@mui/material/FormControl';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
+import PropTypes from 'prop-types';
 import * as React from 'react';
 
-export default function AnalyticsFilter() {
+AnalyticsFilter.propTypes = {
+  searchButtonOnClick: PropTypes.func,
+};
+
+export default function AnalyticsFilter({searchButtonOnClick}) {
   return (
     <Box sx={{my: '24px'}}>
       <Grid container spacing={1}>
@@ -52,7 +57,9 @@ export default function AnalyticsFilter() {
         </Grid>
         <Grid item xs={1}>
           <IconButton>
-            <Button variant="contained">(PLACEHOLDER)</Button>
+            <Button variant="contained" onClick={searchButtonOnClick}>
+              (PLACEHOLDER)
+            </Button>
           </IconButton>
         </Grid>
       </Grid>

--- a/src/analytics/components/AnalyticsMainCard.react.js
+++ b/src/analytics/components/AnalyticsMainCard.react.js
@@ -25,10 +25,10 @@ export default function MainCard() {
           mx: '24px',
           px: '24px',
         }}>
-        <AnalyticsFilter></AnalyticsFilter>
+        <AnalyticsFilter />
         <Divider>RESULTS</Divider>
         <Box sx={{my: '24px'}}>
-          <AnalyticsTable></AnalyticsTable>
+          <AnalyticsTable />
         </Box>
       </Card>
     </Box>

--- a/src/analytics/components/AnalyticsMainCard.react.js
+++ b/src/analytics/components/AnalyticsMainCard.react.js
@@ -4,9 +4,14 @@ import AnalyticsTable from './AnalyticsTable.react';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import Divider from '@mui/material/Divider';
+import PropTypes from 'prop-types';
 import * as React from 'react';
 
-export default function MainCard() {
+AnalyticsMainCard.propTypes = {
+  searchButtonOnClick: PropTypes.func,
+};
+
+export default function AnalyticsMainCard({searchButtonOnClick}) {
   return (
     <Box
       sx={{
@@ -25,7 +30,7 @@ export default function MainCard() {
           mx: '24px',
           px: '24px',
         }}>
-        <AnalyticsFilter />
+        <AnalyticsFilter searchButtonOnClick={searchButtonOnClick} />
         <Divider>RESULTS</Divider>
         <Box sx={{my: '24px'}}>
           <AnalyticsTable />


### PR DESCRIPTION
## Summary

This PR will add the Error Alert popup element. In the future, we want to display this alert when the frontend is unable to retrieve results from the backend. Because there is currently no communication between frontend and backend, we will simply display the alert when clicking on the search button. The Error Alert can be closed by clicking on the 'X' icon on the popup.

## Test Plan

![analyticsErrorAlert](https://user-images.githubusercontent.com/91914689/204460285-e0ade1cc-881f-45e3-a71e-ef565a03e975.gif)
If the main branch behaves as the GIF above does, the goal is reached successfully.
